### PR TITLE
Issue 13

### DIFF
--- a/align/align.go
+++ b/align/align.go
@@ -56,6 +56,15 @@ func NewAligner(in io.Reader, out io.Writer, delimiter rune) Alignable {
 	}
 }
 
+// Init accepts the same arguments as NewAligner.  It simply provides another option
+// for initializing an Aligner which is already allocated.
+func (a *Aligner) Init(in io.Reader, out io.Writer, delimiter rune) {
+	a.S = bufio.NewScanner(in)
+	a.W = bufio.NewWriter(out)
+	a.del = delimiter
+	a.columnCounts = make(map[columnCount]int)
+}
+
 // ColumnCounts scans the input and determines the maximum length of each field based on
 // the longest value for each field in all of the pertaining lines.
 // All of the lines of the io.Reader are returned as a string slice.

--- a/align/align.go
+++ b/align/align.go
@@ -91,9 +91,9 @@ func (a *Aligner) Export(lines []string) {
 
 		var columnNum columnCount
 
-		for i, word := range words {
+		for _, word := range words {
 			// leading padding for all fields except for the first
-			if i > 0 {
+			if columnNum > 0 {
 				word = SingleSpace + word
 			}
 			for len(word) < a.columnCounts[columnNum] {


### PR DESCRIPTION
Fixes #13 

* Removed the check for the existence of the `columnCounts` map.  The original intent was to allow for rows with a different number of delimiters.  This was not working and is now fixed.
* Added an `Init()` method which behaves similarly to `text/tabwriter`.  This simply provides another usage option to initialize the `Aligner`.

