### PR TITLE
Add configurability for input with text qualified fields

### DIFF
--- a/align/align.go
+++ b/align/align.go
@@ -37,34 +37,43 @@ type Alignable interface {
 
 type columnCount int
 
+// TextQualifier is used to configure the scanner to account for a text qualifier
+type TextQualifier struct {
+	On        bool
+	Qualifier rune
+}
+
 // Aligner scans input and writes output
 type Aligner struct {
 	S            *bufio.Scanner
 	W            *bufio.Writer
 	del          rune // delimiter
 	columnCounts map[int]int
+	txtq         TextQualifier
 }
 
 // NewAligner creates and initializes a ScanWriter with in and out as its initial Reader and Writer
 // and sets del to the desired delimiter to be used for alignment.
 // It is meant to read the contents of its io.Reader to determine the length of each field
 // and output the results in an aligned format.
-func NewAligner(in io.Reader, out io.Writer, delimiter rune) Alignable {
+func NewAligner(in io.Reader, out io.Writer, delimiter rune, qualifier TextQualifier) Alignable {
 	return &Aligner{
 		S:            bufio.NewScanner(in),
 		W:            bufio.NewWriter(out),
 		del:          delimiter,
 		columnCounts: make(map[int]int),
+		txtq:         qualifier,
 	}
 }
 
 // Init accepts the same arguments as NewAligner.  It simply provides another option
 // for initializing an Aligner which is already allocated.
-func (a *Aligner) Init(in io.Reader, out io.Writer, delimiter rune) {
+func (a *Aligner) Init(in io.Reader, out io.Writer, delimiter rune, qualifier TextQualifier) {
 	a.S = bufio.NewScanner(in)
 	a.W = bufio.NewWriter(out)
 	a.del = delimiter
 	a.columnCounts = make(map[int]int)
+	a.txtq = qualifier
 }
 
 // ColumnCounts scans the input and determines the maximum length of each field based on
@@ -80,8 +89,26 @@ func (a *Aligner) ColumnCounts() []string {
 
 		for i, v := range line {
 			temp += utf8.RuneLen(v)
-			if v != a.del && i < len(line)-1 {
-				continue
+
+			// if text qualified, count a rune that matches the delimiter as part of the field data
+			if a.txtq.On {
+				inside := false
+				if v == a.txtq.Qualifier {
+					inside = !inside
+				}
+				if inside {
+					if i < len(line)-1 {
+						continue
+					}
+				} else {
+					if v != a.del && i < len(line)-1 {
+						continue
+					}
+				}
+			} else {
+				if v != a.del && i < len(line)-1 {
+					continue
+				}
 			}
 			if temp > a.columnCounts[columnNum] {
 				a.columnCounts[columnNum] = temp
@@ -98,7 +125,12 @@ func (a *Aligner) ColumnCounts() []string {
 // Export will pad each field in lines based on the Aligner's column counts
 func (a *Aligner) Export(lines []string) {
 	for _, line := range lines {
-		words := strings.Split(line, string(a.del))
+		var words []string
+		if a.txtq.On {
+			words = SplitWithQual(line, string(a.del), string(a.txtq.Qualifier))
+		} else {
+			words = SplitWithQual(line, string(a.del), "")
+		}
 
 		var columnNum int
 
@@ -128,4 +160,29 @@ func (a *Aligner) Export(lines []string) {
 		}
 	}
 	a.W.Flush()
+}
+
+// SplitWithQual basically has the same behavior as the standard lib strings.Split with the difference being
+// that a text qualifier can be specified.
+func SplitWithQual(s, sep, qual string) []string {
+	if qual == "" {
+		return strings.Split(s, ",")
+	}
+	var words = make([]string, 0, strings.Count(s, ","))
+	inside := false // inside of the text qualified field
+
+	var start int
+	var end int
+	for i := 0; i < len(s); i++ {
+		if s[i] == qual[0] {
+			inside = !inside
+		}
+		if !inside && s[i] == sep[0] {
+			words = append(words, s[start:end])
+			start = end + 1
+		}
+		end++
+	}
+
+	return words
 }

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func run() (int, error) {
 	sep := ','
 	var input io.Reader
 	var output io.Writer
+	var qu align.TextQualifier
 
 	if flags.Has("sep", args) {
 		delimiter, err := flags.Value("sep", args)
@@ -83,7 +84,19 @@ func run() (int, error) {
 		output = os.Stdout
 	}
 
-	sw := align.NewAligner(input, output, sep)
+	if flags.Has("qual", args) {
+		q, err := flags.Value("qual", args)
+		if err != nil {
+			return 1, err
+		}
+
+		qu = align.TextQualifier{
+			On:        true,
+			Qualifier: []rune(q)[0],
+		}
+	}
+
+	sw := align.NewAligner(input, output, sep, qu)
 
 	lines := sw.ColumnCounts()
 	sw.Export(lines)


### PR DESCRIPTION
Fixes #6 

* add CLI flag to specify a text qualifier
* implement a utility function to split each line much like the standard lib `strings.Split()` but will skip the delimiter if inside of the text qualifier.