### PR TITLE
Align by string instead of single character

### DIFF
--- a/align/align_test.go
+++ b/align/align_test.go
@@ -6,6 +6,83 @@ import (
 	"testing"
 )
 
+var columnCountCases = []struct {
+	input  string
+	sep    string
+	isQual bool
+	qual   string
+	counts map[int]int
+}{
+	{
+		"John,Doe,Henry\nMichael,Douglas,F",
+		",",
+		false,
+		"",
+		map[int]int{
+			0: 7,
+			1: 7,
+			2: 5,
+		},
+	},
+	{
+		"John,Doe,\"Henry, Mellencamp\",jm@nothing.com\nMichael,Douglas,F",
+		",",
+		true,
+		"\"",
+		map[int]int{
+			0: 7,
+			1: 7,
+			2: 19,
+		},
+	}, {
+		"John,Doe,\"Henry, Mellencamp\",jm@nothing.com\nMichael,Douglas,F",
+		",",
+		true,
+		"\"",
+		map[int]int{
+			0: 7,
+			1: 7,
+			2: 19,
+		},
+	},
+	{
+		"one||two||three||four\nuno||dos||tres||quatro",
+		"||",
+		true,
+		"",
+		map[int]int{
+			0: 3,
+			1: 3,
+			2: 5,
+			3: 6,
+		},
+	},
+	{
+		"one||\"two|| number\"||three||four\nuno||dos||\"tres|\"||quatro",
+		"||",
+		true,
+		"\"",
+		map[int]int{
+			0: 3,
+			1: 14,
+			2: 7,
+			3: 6,
+		},
+	},
+}
+
+func TestColumnCounts(t *testing.T) {
+	for _, tt := range columnCountCases {
+		aligner := NewAligner(strings.NewReader(tt.input), os.Stdout, tt.sep, TextQualifier{On: tt.isQual, Qualifier: tt.qual})
+		aligner.ColumnCounts()
+		for i := range tt.counts {
+			if aligner.ColumnSize(i) != tt.counts[i] {
+				t.Fatalf("Count for column %v = %v, want %v", i, aligner.ColumnSize(i), tt.counts[i])
+			}
+		}
+	}
+}
+
 func BenchmarkColumnCounts(b *testing.B) {
 	input := `First,Middle,Last,Email,Region,City,Zip,Full_Name,First,Middle,Last,Email,Region,City,Zip,Full_Name,First,Middle,Last,Email,Region,City,Zip,Full_Name
 Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly,Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly,Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reilly        
@@ -16,7 +93,7 @@ Karleigh,Destiny,Dean,nunc.In@lorem.edu,Stockholms län,Märsta,9038,Shaine Reil
 Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez ,Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivia Velez         
 `
 
-	sw := NewAligner(strings.NewReader(input), os.Stdout, ',', TextQualifier{On: false})
+	sw := NewAligner(strings.NewReader(input), os.Stdout, ",", TextQualifier{On: false})
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -29,7 +106,7 @@ Alisa,Walker,Armand,Sed@Nuncmauriselit.com,Himachal Pradesh,Shimla,MZ0 4QS,Olivi
 func BenchmarkSplitWithQual(b *testing.B) {
 	input := "First,\"Middle, name\",Last,Email,Region,City,Zip,Full_Name"
 
-	sw := NewAligner(strings.NewReader(input), os.Stdout, ',', TextQualifier{On: true, Qualifier: '"'})
+	sw := NewAligner(strings.NewReader(input), os.Stdout, ",", TextQualifier{On: true, Qualifier: "\""})
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -42,7 +119,7 @@ func BenchmarkSplitWithQual(b *testing.B) {
 func BenchmarkSplitWithQualNoQual(b *testing.B) {
 	input := "First,Middle,Last,Email,Region,City,Zip,Full_Name"
 
-	sw := NewAligner(strings.NewReader(input), os.Stdout, ',', TextQualifier{On: false})
+	sw := NewAligner(strings.NewReader(input), os.Stdout, ",", TextQualifier{On: false})
 
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func run() (int, error) {
 	args := os.Args[1:]
 
 	// defaults
-	sep := ','
+	sep := ","
 	var input io.Reader
 	var output io.Writer
 	var qu align.TextQualifier
@@ -47,7 +47,7 @@ func run() (int, error) {
 		if err != nil {
 			return 1, err
 		}
-		sep = []rune(delimiter)[0]
+		sep = delimiter
 	}
 
 	// check for piped input, but use specified input file if supplied
@@ -111,7 +111,7 @@ func run() (int, error) {
 
 		qu = align.TextQualifier{
 			On:        true,
-			Qualifier: []rune(q)[0],
+			Qualifier: q,
 		}
 	}
 	sw := align.NewAligner(input, output, sep, qu)


### PR DESCRIPTION
Provides a significant refactor and Fixes #18 .

* `sep` to align by can now be a string instead of a single rune
* implement a couple of helper functions to determine field lengths
* fix `SplitWithQual()` to use new helpers and split a text qualified field while properly escaping the `sep` string if it exists within the data itself.
* update tests