### PR TITLE
Specify left | right | center justification

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ Another use is to align blocks of code by `=` or `->`, etc.
 
 
 ### Usage - CLI examples
+
+```
+Usage: true-up [-sep] [-output] [-file] [-qual] [-jstfy]
+Options:
+  -h | --help  : help
+  -file        : input file.  If not specified, pipe input to stdin
+  -output      : output file. (defaults to stdout)
+  -qual        : text qualifier (if applicable)
+  -sep         : delimiter. (defaults to ',')
+  -left        : left justification. (default)
+  -center      : center justification
+  -right       : right justification
+```
+
 _Specify your input file, output file, delimiter._
 *You can also pipe input to Stdin (if the `-file` option is provided, it will overwrite Stdin)*
 If no `-output` option is provided, Stdout will be used.

--- a/align/align.go
+++ b/align/align.go
@@ -216,6 +216,12 @@ func pad(s string, columnNum, count int, p PaddingOpts) string {
 	case JustifyRight:
 		s = leadingPad(s, padLength)
 	case JustifyCenter:
+		if padLength > 2 {
+			s = trailingPad(s, padLength/2)
+			s = leadingPad(s, padLength-(padLength/2))
+		} else {
+			s = trailingPad(s, padLength)
+		}
 
 	default:
 		s = trailingPad(s, padLength)

--- a/align/align_test.go
+++ b/align/align_test.go
@@ -69,6 +69,16 @@ var columnCountCases = []struct {
 			3: 6,
 		},
 	},
+	{
+		"one,tisß\nseven,two", // with byte count > 1
+		",",
+		false,
+		"",
+		map[int]int{
+			0: 5,
+			1: 5,
+		},
+	},
 }
 
 func TestColumnCounts(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -10,13 +10,16 @@ import (
 	"github.com/fatih/flags"
 )
 
-const usage = `Usage: true-up [-sep] [-output] [-file] [-qual]
+const usage = `Usage: true-up [-sep] [-output] [-file] [-qual] [-jstfy]
 Options:
   -h | --help  : help
   -file        : input file.  If not specified, pipe input to stdin
   -output      : output file. (defaults to stdout)
   -qual        : text qualifier (if applicable)
   -sep         : delimiter. (defaults to ',')
+  -left        : left justification. (default)
+  -center      : center justification
+  -right       : right justification
 `
 
 func main() {
@@ -114,7 +117,16 @@ func run() (int, error) {
 			Qualifier: q,
 		}
 	}
+
 	sw := align.NewAligner(input, output, sep, qu)
+
+	if flags.Has("left", args) {
+		sw.UpdatePadding(align.PaddingOpts{Justification: align.JustifyLeft})
+	} else if flags.Has("right", args) {
+		sw.UpdatePadding(align.PaddingOpts{Justification: align.JustifyRight})
+	} else if flags.Has("center", args) {
+		sw.UpdatePadding(align.PaddingOpts{Justification: align.JustifyCenter})
+	}
 
 	lines := sw.ColumnCounts()
 	sw.Export(lines)


### PR DESCRIPTION
This resolves #27.

* add a `PaddingOpts` type which configures the justification of each field for now.  In the future, it will provide even more configurability for padding.
* add CLI usage to the REAME.
* move most of the padding logic to new helper functions which are able to prepend padding, append padding, or both.